### PR TITLE
Replace deprecated names with their identicals.

### DIFF
--- a/dciknn/core.py
+++ b/dciknn/core.py
@@ -104,7 +104,7 @@ class DCI(object):
     def _check_array(self, arr):
         if arr.shape[1] != self.dim:
             raise ValueError("mismatch between array dimension (%d) and the declared dimension of this DCI instance (%d)" % (arr.shape[1],self.dim))
-        if arr.dtype != np.float:
+        if arr.dtype != float:
             raise TypeError("array must consist of double-precision floats")
         if not arr.flags.c_contiguous:
             raise ValueError("the memory layout of array must be in row-major (C-order)")
@@ -112,10 +112,10 @@ class DCI(object):
     def _check_and_fix_array(self, arr):
         if arr.shape[1] != self.dim:
             raise ValueError("mismatch between array dimension (%d) and the declared dimension of this DCI instance (%d)" % (arr.shape[1],self.dim))
-        if arr.dtype == np.float and arr.flags.c_contiguous:
+        if arr.dtype == float and arr.flags.c_contiguous:
             return arr
         else:
-            return np.array(arr, dtype=np.float, copy=False, order='C')
+            return np.array(arr, dtype=float, copy=False, order='C')
     
     def _check_is_base_array(self, arr):
         # arr cannot be derived from some other array (except if it's just transposed, in which case the data pointer stays the same)
@@ -177,7 +177,7 @@ class DCI(object):
                         selected_idx = np.copy(selected_idx)
                         selected_idx[selected_idx < 0] += data.shape[0]
                     check_indices_within_bounds = True
-                elif indices.dtype == np.bool:
+                elif indices.dtype == bool:
                     if indices.shape[0] == data.shape[0]:
                         selected_idx = np.nonzero(indices)[0].astype(np.intc)
                     else:


### PR DESCRIPTION
Based on the [release note](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations), this PR updates the deprecated types with the suggested types.